### PR TITLE
Use plain json instead of simplejson

### DIFF
--- a/gzipServer.py
+++ b/gzipServer.py
@@ -8,7 +8,7 @@ import time
 import sys
 import BaseHTTPServer
 import gzip
-import simplejson as json
+import json
 import argparse
 
 HOST_NAME = '127.0.0.1'


### PR DESCRIPTION
json is always available with modern versions of python, simplejson is not. simplejson is sometimes
faster than json, but that's not really a concern with test code like this.